### PR TITLE
removed FrontendRestrictionContainer from query restrictions

### DIFF
--- a/Classes/Frontend/Middleware/SiteResolver.php
+++ b/Classes/Frontend/Middleware/SiteResolver.php
@@ -132,7 +132,6 @@ class SiteResolver implements MiddlewareInterface
             $path = preg_replace('/(^\/)|(\/$)|(\/(?!.*\/).*\..*)/', '$1', $path); // allow / or filename after slug
             if (!empty($path)) {
                 $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('pages');
-                $queryBuilder->getRestrictions()->removeAll()->add(new FrontendRestrictionContainer());
                 $queryBuilder->select('*')
                              ->from('pages')
                              ->where($queryBuilder->expr()->eq('slug', $queryBuilder->createNamedParameter($path)));


### PR DESCRIPTION
Allows setting page permissions with the extension "felogin".
Now, the page is found by matching incoming URL if the access to a page is granted (if user has been logged in or IP is allowed)